### PR TITLE
Make a version of Measurement that uses ComparableQuantity instead of plain Quantity for better consistency with the rest of UOM, better type safety, and closer consistency to the indtended functionality of Comparable.

### DIFF
--- a/src/main/java/tec/uom/se/spi/AbstractMeasurement.java
+++ b/src/main/java/tec/uom/se/spi/AbstractMeasurement.java
@@ -135,7 +135,7 @@ abstract class AbstractMeasurement<Q extends Quantity<Q>> implements Measurement
    * This class represents the default measurement.
    */
   @SuppressWarnings("rawtypes")
-  static final class Default<Q> extends AbstractMeasurement {
+  static final class Default<Q extends Quantity<Q>> extends AbstractMeasurement<Q> {
 
     /**
 		 *
@@ -162,7 +162,8 @@ abstract class AbstractMeasurement<Q extends Quantity<Q>> implements Measurement
 	 * This class represents the default measurement.
 	 */
 	@SuppressWarnings("rawtypes")
-	static final class DefaultComparableQ<Q> extends AbstractMeasurement implements MeasurementComparableQ {
+	static final class DefaultComparableQ<Q extends Quantity<Q>> extends AbstractMeasurement<Q>
+		implements MeasurementComparableQ<Q> {
 
 		//TODO: Maybe add serialVersionUID?
 
@@ -182,8 +183,8 @@ abstract class AbstractMeasurement<Q extends Quantity<Q>> implements Measurement
 		}
 
 		@Override
-		public ComparableQuantity getQuantity() {
-			return (ComparableQuantity) super.getQuantity();
+		public ComparableQuantity<Q> getQuantity() {
+			return (ComparableQuantity<Q>) super.getQuantity();
 		}
 	}
 }

--- a/src/main/java/tec/uom/se/spi/AbstractMeasurement.java
+++ b/src/main/java/tec/uom/se/spi/AbstractMeasurement.java
@@ -39,18 +39,18 @@ import tec.uom.se.ComparableQuantity;
  * <p>
  * This class represents the immutable result of a measurement stated in a known quantity.
  * </p>
- * 
+ *
  * <p>
  * All instances of this class shall be immutable.
  * </p>
- * 
+ *
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
  * @version 0.3 $Date: 2015-07-25 $
  */
 abstract class AbstractMeasurement<Q extends Quantity<Q>> implements Measurement<Q> {
 
   /**
-	 * 
+	 *
 	 */
   private static final long serialVersionUID = 2417644773551236879L;
 
@@ -84,7 +84,7 @@ abstract class AbstractMeasurement<Q extends Quantity<Q>> implements Measurement
    *
    * @return the quantity.
    */
-  public final Quantity<Q> getQuantity() {
+  public Quantity<Q> getQuantity() {
     return quantity;
   }
 
@@ -106,14 +106,39 @@ abstract class AbstractMeasurement<Q extends Quantity<Q>> implements Measurement
     return instant.toEpochMilli();
   }
 
-  /**
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		AbstractMeasurement<?> that = (AbstractMeasurement<?>) o;
+
+		return quantity.equals(that.quantity) && instant.equals(that.instant);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = quantity.hashCode();
+		result = 31 * result + instant.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "Measurement{" +
+			"quantity=" + quantity +
+			", instant=" + instant +
+			'}';
+	}
+
+	/**
    * This class represents the default measurement.
    */
   @SuppressWarnings("rawtypes")
   static final class Default<Q> extends AbstractMeasurement {
 
     /**
-		 * 
+		 *
 		 */
     private static final long serialVersionUID = 823899472806334856L;
 
@@ -131,19 +156,34 @@ abstract class AbstractMeasurement<Q extends Quantity<Q>> implements Measurement
     protected Default(Quantity q) {
       super(q);
     }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public int compareTo(Object o) {
-      if (o instanceof Measurement) {
-        Measurement m = (Measurement) o;
-        if (getQuantity() instanceof ComparableQuantity) {
-          ComparableQuantity<?> comp = (ComparableQuantity<?>) getQuantity();
-          return comp.compareTo(m.getQuantity()) + getInstant().compareTo(m.getInstant());
-        }
-        return 0;
-      }
-      return 0;
-    }
   }
+
+	/**
+	 * This class represents the default measurement.
+	 */
+	@SuppressWarnings("rawtypes")
+	static final class DefaultComparableQ<Q> extends AbstractMeasurement implements MeasurementComparableQ {
+
+		//TODO: Maybe add serialVersionUID?
+
+		@SuppressWarnings({ "unchecked" })
+		protected DefaultComparableQ(ComparableQuantity q, Instant i) {
+			super(q, i);
+		}
+
+		@SuppressWarnings({ "unchecked" })
+		protected DefaultComparableQ(ComparableQuantity q, long t) {
+			super(q, t);
+		}
+
+		@SuppressWarnings("unchecked")
+		protected DefaultComparableQ(ComparableQuantity q) {
+			super(q);
+		}
+
+		@Override
+		public ComparableQuantity getQuantity() {
+			return (ComparableQuantity) super.getQuantity();
+		}
+	}
 }

--- a/src/main/java/tec/uom/se/spi/Measurement.java
+++ b/src/main/java/tec/uom/se/spi/Measurement.java
@@ -61,12 +61,6 @@ public interface Measurement<Q extends Quantity<Q>> extends QuantitySupplier<Q>,
 	 * @return a timestamp.
 	 */
 	long getTimestamp();
-	/**
-	 * Returns the measurement quantity.
-	 *
-	 * @return the quantity.
-	 */
-	Quantity<Q> getQuantity();
 
 	/**
 	 * Returns the {@linkplain Instant} as timestamp.

--- a/src/main/java/tec/uom/se/spi/Measurement.java
+++ b/src/main/java/tec/uom/se/spi/Measurement.java
@@ -37,45 +37,62 @@ import java.time.Instant;
 import javax.measure.Quantity;
 
 import tec.uom.lib.common.function.QuantitySupplier;
+import tec.uom.se.ComparableQuantity;
 
 /**
  * A Measurement contains a {@link Quantity} and a timestamp.
- * 
+ *
  * <p>
  * A {@code Measurement} object is used for maintaining the tuple of quantity and time-stamp.
  * The value is represented as {@linkplain Quantity}
  * and the time as {@linkplain Instant} plus <type>long</type> for backward-compatibility.
  * <p>
- * 
+ *
  * @see {@link QuantitySupplier}
  * @author werner
  * @version 0.5
  * @param <Q>
  */
-public interface Measurement<Q extends Quantity<Q>> extends QuantitySupplier<Q>,
-		Comparable<Measurement<Q>>, Serializable {
+public interface Measurement<Q extends Quantity<Q>> extends QuantitySupplier<Q>, Serializable {
 
 	/**
 	 * Returns the timestamp of this {@link Measurement}.
-	 * 
+	 *
 	 * @return a timestamp.
 	 */
 	long getTimestamp();
-	
+	/**
+	 * Returns the measurement quantity.
+	 *
+	 * @return the quantity.
+	 */
+	Quantity<Q> getQuantity();
+
 	/**
 	 * Returns the {@linkplain Instant} as timestamp.
-	 * 
+	 *
 	 * @return an instant.
 	 */
 	Instant getInstant();
-	
+
 	@SuppressWarnings({ "unchecked" })
 	static <Q extends Quantity<Q>> Measurement<Q> of(Quantity<Q> q) {
 		return new Default<>(q);
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	static <Q extends Quantity<Q>> Measurement<Q> of(Quantity<Q> q, Instant i) {
 		return new Default<>(q, i);
 	}
+
+	@SuppressWarnings({ "unchecked" })
+	static <Q extends Quantity<Q>> MeasurementComparableQ<Q> of(ComparableQuantity<Q> q) {
+		return new AbstractMeasurement.DefaultComparableQ<>(q);
+	}
+
+	@SuppressWarnings("unchecked")
+	static <Q extends Quantity<Q>> MeasurementComparableQ<Q> of(ComparableQuantity<Q> q, Instant i) {
+		return new AbstractMeasurement.DefaultComparableQ<>(q, i);
+	}
+
 }

--- a/src/main/java/tec/uom/se/spi/MeasurementComparableQ.java
+++ b/src/main/java/tec/uom/se/spi/MeasurementComparableQ.java
@@ -1,0 +1,18 @@
+package tec.uom.se.spi;
+
+import tec.uom.se.ComparableQuantity;
+
+import javax.measure.Quantity;
+
+
+public interface MeasurementComparableQ<Q extends Quantity<Q>> extends Measurement<Q> {
+
+	/**
+	 * Returns the measurement quantity.
+	 *
+	 * @return the quantity.
+	 */
+	@Override
+	ComparableQuantity<Q> getQuantity();
+
+}

--- a/src/main/java/tec/uom/se/spi/MeasurementComparableQ.java
+++ b/src/main/java/tec/uom/se/spi/MeasurementComparableQ.java
@@ -1,3 +1,32 @@
+/*
+ * Units of Measurement Implementation for Java SE
+ * Copyright (c) 2005-2016, Jean-Marie Dautelle, Werner Keil, V2COM.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-363 nor the names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package tec.uom.se.spi;
 
 import tec.uom.se.ComparableQuantity;


### PR DESCRIPTION
* Added MeasurementComparableQ interface which is more specific about the type of the Quantity (ComparableQuantity instead of just Quantity).
* Moved getQuantity() to Measurement interface from AbstractMeasurement class.
* Removed final modifier from getQuantity() in AbstractMeasurement.
* Measurement no longer implements comparable, instead a MeasurementComparableQ can be returned and the Quantity it contains can be compared with others.
* Added two new overloaded static of(ComparableQuantity q) methods to Measurement that take ComparableQuantities instead of plain Quantities and return DefaultComparableQ as MeasurementComparableQ instead of Default as Measurement.
* Overrode equals(), hashCode(), and toString() in AbstractMeasurement.